### PR TITLE
Remove Blog Search Results and Clear Filters Button Temporarily

### DIFF
--- a/packages/components/src/components/CollectionFiltered/CollectionFiltered.theme.ts
+++ b/packages/components/src/components/CollectionFiltered/CollectionFiltered.theme.ts
@@ -11,6 +11,13 @@ export const styleOverrides: ComponentsOverrides<Theme>['CollectionFiltered'] = 
       // '[class*=CollectionFiltered-contentContainer]': {
       //   padding: '0 !important'
       // }
+      // Temporarily hiding the "All search results" display and "Clear filters" button
+      '& [data-testid="CollectionFiltered-ResultsDisplay"]': {
+        display: 'none' // Hides the results display
+      },
+      '& [data-testid="CollectionFilters-clear"]': {
+        display: 'none' // Hides the clear filters button
+      }
     };
   }
 };


### PR DESCRIPTION
This PR addresses a requirement to temporarily hide certain elements within the `CollectionFiltered` component. Specifically, the following changes have been made:

- **Hiding "All Search Results" Display**: 
  - Added a new style override that sets `display: none` for the element identified by `data-testid="CollectionFiltered-ResultsDisplay"`. This ensures that the "All search results" section will not be visible to users.
  
- **Hiding "Clear Filters" Button**: 
  - Similarly, a style override has been added to hide the "Clear filters" button by setting `display: none` for the element with `data-testid="CollectionFilters-clear"`.
  
These changes are intended to improve the user experience by temporarily removing these elements, which may not be necessary or relevant in the current UI. All original comments in the code have been preserved, and additional comments have been added to clarify the purpose of the new styles.

**Files Affected:**
- `packages/components/src/components/CollectionFiltered/CollectionFiltered.theme.ts`

No other files were modified, and there are no deletions in this PR. Please review the changes and provide feedback as needed.
